### PR TITLE
Fix ctypes.windll crash on non-Windows systems

### DIFF
--- a/files/main.py
+++ b/files/main.py
@@ -1,5 +1,12 @@
 import ctypes
-ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID("ToAshAgain.unique.id")
+
+# Set the application ID on Windows so the taskbar icon shows correctly.
+# This call is Windows specific and will raise an AttributeError on other
+# platforms, so guard it with a check.
+if hasattr(ctypes, "windll") and hasattr(ctypes.windll, "shell32"):
+    ctypes.windll.shell32.SetCurrentProcessExplicitAppUserModelID(
+        "ToAshAgain.unique.id"
+    )
 
 import pygame
 import sys


### PR DESCRIPTION
## Summary
- guard `ctypes.windll.shell32` usage behind a platform check

## Testing
- `python -m py_compile files/*.py`

------
https://chatgpt.com/codex/tasks/task_e_683fff3064548321b5cea85b97314fb8